### PR TITLE
Change text-decoration-skip value from 'ink' to 'initial'

### DIFF
--- a/unnormalize.css
+++ b/unnormalize.css
@@ -9,7 +9,7 @@
  */
  
 a {
-  -webkit-text-decoration-skip: initial;
-  text-decoration-skip: initial; 
+  -webkit-text-decoration-skip: revert;
+  text-decoration-skip: revert; 
 }
  

--- a/unnormalize.css
+++ b/unnormalize.css
@@ -9,7 +9,7 @@
  */
  
 a {
-  -webkit-text-decoration-skip: ink;
-  text-decoration-skip: ink;
+  -webkit-text-decoration-skip: initial;
+  text-decoration-skip: initial; 
 }
  


### PR DESCRIPTION
Hi Nicolas, 

Since `ink` seems to be the default behavior in iOS 8+ and Safari 8+, why not simply set `text-decoration-skip` back to its `initial` value (specially if the purpose of this stylesheet is **only** to unnormalize)?

Also, this is my first PR, so let me know if I did something wrong. ;)
